### PR TITLE
bump placeholder api version to fix motd

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -20,7 +20,7 @@ archives_base_name = essential_commands
 
 # Dependencies
 permissions_api_version=0.3.3
-placeholder_api_version=2.5.0+1.21.2
+placeholder_api_version=2.6.2+1.21.5
 pal_version=1.13.0
 vanish_version=1.5.3+1.20.4
 


### PR DESCRIPTION
The Placeholder api needed a version bump to allow motd to work under 1.21.5.

Sorry for the mistaken PRs before.
